### PR TITLE
Update main.less to fix #1510

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -576,6 +576,7 @@ thead {
   margin: 0 auto;
   position: relative;
   top: 50%;
+  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 


### PR DESCRIPTION
Update `main.less` to fix #1510. There was an alignment issue on Safari because of missing vendor prefix on `transform` on `.points-on-top class`.
